### PR TITLE
CV-222 CV-240 CommitmentsConsume auth handler

### DIFF
--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.NUnit3" Version="4.8.0" />
-    <PackageReference Include="CompareNETObjects" Version="4.57.0" />
+    <PackageReference Include="CompareNETObjects" Version="4.58.0" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
@@ -16,7 +16,7 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1462" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.NUnit3" Version="4.8.0" />
-    <PackageReference Include="CompareNETObjects" Version="4.57.0" />
+    <PackageReference Include="CompareNETObjects" Version="4.58.0" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1462" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/AuthorizationContextExtensions.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/AuthorizationContextExtensions.cs
@@ -1,0 +1,16 @@
+using SFA.DAS.Authorization;
+using SFA.DAS.Authorization.CommitmentPermissions;
+using SFA.DAS.CommitmentsV2.Types;
+
+namespace SFA.DAS.ProviderCommitments.Web.Authorization
+{
+    public static class AuthorizationContextExtensions
+    {
+        public static void AddCommitmentPermissionValues(this IAuthorizationContext authorizationContext, long? cohortId, Party? partyType, long partyId)
+        {
+            authorizationContext.Set(AuthorizationContextKey.CohortId, cohortId);
+            authorizationContext.Set(AuthorizationContextKey.Party, partyType);
+            authorizationContext.Set(AuthorizationContextKey.PartyId, partyId);
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/AuthorizationContextProvider.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/AuthorizationContextProvider.cs
@@ -47,32 +47,12 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
 
         private long? GetAccountLegalEntityId()
         {
-            if (!TryGetValueFromHttpContext(RouteValueKeys.AccountLegalEntityPublicHashedId, out var accountLegalEntityPublicHashedId))
-            {
-                return null;
-            }
-            
-            if (!_encodingService.TryDecode(accountLegalEntityPublicHashedId, EncodingType.PublicAccountLegalEntityId, out var accountLegalEntityId))
-            {
-                throw new UnauthorizedAccessException();
-            }
-
-            return accountLegalEntityId;
+            return GetAndDecodeValueIfExists(RouteValueKeys.AccountLegalEntityPublicHashedId, EncodingType.PublicAccountLegalEntityId);
         }
 
         private long? GetDraftApprenticeshipId()
         {
-            if (!TryGetValueFromHttpContext(RouteValueKeys.DraftApprenticeshipId, out var draftApprenticeshipHashedId))
-            {
-                return null;
-            }
-
-            if (!_encodingService.TryDecode(draftApprenticeshipHashedId, EncodingType.ApprenticeshipId, out var draftApprenticeshipId))
-            {
-                throw new UnauthorizedAccessException();
-            }
-
-            return draftApprenticeshipId;
+            return GetAndDecodeValueIfExists(RouteValueKeys.DraftApprenticeshipId, EncodingType.ApprenticeshipId);
         }
 
         private long? GetUkrpn()
@@ -136,6 +116,23 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
             }
 
             return true;
+        }
+
+        private long? GetAndDecodeValueIfExists(string keyName, EncodingType encodedType)
+        {
+            // The value in the context is optional but if there is a value then it should be valid (i.e. it should be decodable
+            // using the specified encoder type).
+            if (!TryGetValueFromHttpContext(keyName, out var encodedValue))
+            {
+                return null;
+            }
+
+            if (!_encodingService.TryDecode(encodedValue, encodedType, out var id))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            return id;
         }
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/ProviderHandler.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/ProviderHandler.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 
-namespace SFA.DAS.ProviderCommitments.Web.Authorisation
+namespace SFA.DAS.ProviderCommitments.Web.Authorization
 {
     /// <summary>
     ///     If the current route contains a {ProviderId} parameter (case is not sensitive) then this handler

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/ProviderRequirement.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/ProviderRequirement.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 
-namespace SFA.DAS.ProviderCommitments.Web.Authorisation
+namespace SFA.DAS.ProviderCommitments.Web.Authorization
 {
     public class ProviderRequirement : IAuthorizationRequirement
     {

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Controllers/DraftApprenticeshipController.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Controllers/DraftApprenticeshipController.cs
@@ -2,6 +2,8 @@
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Authorization.CommitmentPermissions;
+using SFA.DAS.Authorization.Mvc;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
 using SFA.DAS.CommitmentsV2.Api.Types.Validation;
 using SFA.DAS.ProviderCommitments.Domain_Models.ApprenticeshipCourse;
@@ -19,7 +21,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Controllers
 {
 
     [Route("{providerId}/unapproved/{cohortReference}/apprentices")]
-    [Authorize()]
+    [DasAuthorize(CommitmentOperation.AccessCohort)]
     public class DraftApprenticeshipController : Controller
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/CommitmentsApiRegistry.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/CommitmentsApiRegistry.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Options;
+﻿using SFA.DAS.Authorization.CommitmentPermissions;
+using SFA.DAS.Authorization.CommitmentPermissions.Client;
 using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.CommitmentsV2.Api.Client.Configuration;
 using SFA.DAS.CommitmentsV2.Api.Client.DependencyResolution;
@@ -11,11 +12,12 @@ namespace SFA.DAS.ProviderCommitments.Web.DependencyResolution
         public CommitmentsApiRegistry()
         {
             IncludeRegistry<CommitmentsApiClientRegistry>();
+
             For<ICommitmentsApiClientFactory>().Use("", x =>
             {
                 var config = x.GetInstance<CommitmentsClientApiConfiguration>();
                 return new CommitmentsApiClientFactory(config);
-            });
+            }).Singleton();
         }
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/CommitmentsPermissionsApiRegistry.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/CommitmentsPermissionsApiRegistry.cs
@@ -1,0 +1,21 @@
+﻿using SFA.DAS.Authorization.CommitmentPermissions;
+using SFA.DAS.Authorization.CommitmentPermissions.Client;
+using SFA.DAS.CommitmentsV2.Api.Client.Configuration;
+using StructureMap;
+
+namespace SFA.DAS.ProviderCommitments.Web.DependencyResolution
+{
+    public class CommitmentsPermissionsApiRegistry : Registry
+    {
+        public CommitmentsPermissionsApiRegistry()
+        {
+            IncludeRegistry<CommitmentPermissionsAuthorizationRegistry>();
+
+            For<ICommitmentPermissionsApiClientFactory>().Use("", ctx =>
+            {
+                var config = ctx.GetInstance<CommitmentsClientApiConfiguration>();
+                return new CommitmentPermissionsApiClientFactory(config);
+            }).Singleton();
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/DefaultRegistry.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/DefaultRegistry.cs
@@ -5,7 +5,7 @@ using SFA.DAS.ProviderCommitments.Infrastructure;
 using SFA.DAS.ProviderCommitments.Interfaces;
 using SFA.DAS.ProviderCommitments.Services;
 using SFA.DAS.ProviderCommitments.Web.Authentication;
-using SFA.DAS.ProviderCommitments.Web.Authorisation;
+using SFA.DAS.ProviderCommitments.Web.Authorization;
 using SFA.DAS.ProviderRelationships.Api.Client;
 using SFA.DAS.ProviderUrlHelper;
 using StructureMap;
@@ -28,11 +28,11 @@ namespace SFA.DAS.ProviderCommitments.Web.DependencyResolution
 
             //For<ServiceFactory>().Use<ServiceFactory>(ctx => ctx.GetInstance);
             //For<IMediator>().Use<Mediator>();
-            For<IAuthenticationService>().Use<AuthenticationService>();
-            For<IAuthorizationContextProvider>().Use<AuthorizationContextProvider>();
+            For<IAuthenticationService>().Use<AuthenticationService>().Singleton();
+            For<IAuthorizationContextProvider>().Use<AuthorizationContextProvider>().Singleton();
             For<ICache>().Use<InMemoryCache>().Singleton();
             For<ICurrentDateTime>().Use<CurrentDateTime>().Singleton();
-            For<ILinkGenerator>().Use<LinkGenerator>();
+            For<ILinkGenerator>().Use<LinkGenerator>().Singleton();
             Toggle<IProviderRelationshipsApiClient, StubProviderRelationshipsApiClient>("UseStubProviderRelationships");
         }
         

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/IoC.cs
@@ -1,4 +1,6 @@
 ﻿using SFA.DAS.Authorization;
+using SFA.DAS.Authorization.CommitmentPermissions;
+using SFA.DAS.Authorization.CommitmentPermissions.Client;
 using SFA.DAS.Authorization.ProviderPermissions;
 using SFA.DAS.AutoConfiguration.DependencyResolution;
 using SFA.DAS.ProviderCommitments.DependencyResolution;
@@ -10,16 +12,18 @@ namespace SFA.DAS.ProviderCommitments.Web.DependencyResolution
     {
         public static void Initialize(Registry registry)
         {
-            registry.IncludeRegistry<DefaultRegistry>();
-
             registry.IncludeRegistry<AuthorizationRegistry>();
             registry.IncludeRegistry<ConfigurationRegistry>();
             registry.IncludeRegistry<CommitmentsApiRegistry>();
+            registry.IncludeRegistry<CommitmentsPermissionsApiRegistry>();
             registry.IncludeRegistry<ConfigurationRegistry>();
             registry.IncludeRegistry<EncodingRegistry>();
             registry.IncludeRegistry<MediatorRegistry>();
             registry.IncludeRegistry<AutoConfigurationRegistry>();
             registry.IncludeRegistry<ProviderPermissionsAuthorizationRegistry>();
+
+            // This needs to go last as it replaces some of the default registrations in the package registartion above.
+            registry.IncludeRegistry<DefaultRegistry>();
         }
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Extensions/AuthorizationPolicyBuilderExtensions.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Extensions/AuthorizationPolicyBuilderExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using SFA.DAS.ProviderCommitments.Web.Authorisation;
+using SFA.DAS.ProviderCommitments.Web.Authorization;
 
 namespace SFA.DAS.ProviderCommitments.Web.Extensions
 {

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Extensions/IServiceCollectionExtensions.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Extensions/IServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using SFA.DAS.Configuration.AzureTableStorage;
 using SFA.DAS.ProviderCommitments.Configuration;
-using SFA.DAS.ProviderCommitments.Web.Authorisation;
+using SFA.DAS.ProviderCommitments.Web.Authorization;
 
 namespace SFA.DAS.ProviderCommitments.Web.Extensions
 {

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
@@ -22,7 +22,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.8.0" />
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="4.2.12" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1462" />
+    <PackageReference Include="SFA.DAS.Authorization.CommitmentPermissions" Version="4.3.52" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1479" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.1" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="SFA.DAS.ProviderUrlHelper" Version="1.1.687" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
@@ -17,8 +17,9 @@
     <PackageReference Include="MediatR" Version="6.0.0" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.98" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.98" />
-    <PackageReference Include="SFA.DAS.Authorization.ProviderPermissions" Version="4.2.12" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1462" />
+    <PackageReference Include="SFA.DAS.Authorization.ProviderPermissions" Version="4.3.52" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1479" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />


### PR DESCRIPTION
This is the last part of the story to secure the cohorts can be accessed by providers entitled. 

There are three moving parts to this story:

1. Updated SFA Authorization nugets to add in support for commitments permissions (and an auth caching mechanism). This is not part of this PR (but this PR does consume the updated nugets packages)

2. An updated Commitments API to allow authorization related queries. This is not part of this PR (but this PR does consume the updated nuget packages)

3. An updated Provider Commitments web to use the new auth handler. This is the purpose of this PR. 
The main points of this PR are: 
      i) to update the commitments permission authUpdate packages

      ii) fix up IoC registrations

      iii) wire up the new commitment authorization handler
