### PR TITLE
CV-244 Prevent framework courses from being available to transfer funded cohorts

### DIFF
--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
@@ -16,7 +16,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/DraftApprenticeshipControllerTestFixture.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/DraftApprenticeshipControllerTestFixture.cs
@@ -191,6 +191,14 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Controllers.DraftApprentices
             return this;
         }
 
+        public DraftApprenticeshipControllerTestFixture SetupCohortTransferFundedStatus(bool isFundedByTransfer)
+        {
+            _providerCommitmentsService
+                .Setup(pcs => pcs.GetCohortDetail(_cohortId))
+                .ReturnsAsync(new CohortDetails {CohortId = _cohortId, IsFundedByTransfer = isFundedByTransfer });
+            return this;
+        }
+
         public DraftApprenticeshipControllerTestFixture VerifyAddViewHasCohortButWithoutAReservationId()
         {
             Assert.IsInstanceOf<ViewResult>(_actionResult);
@@ -305,6 +313,16 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Controllers.DraftApprentices
         public DraftApprenticeshipControllerTestFixture VerifyWeGetABadRequestResponse()
         {
             Assert.IsInstanceOf<BadRequestObjectResult>(_actionResult);
+            return this;
+        }
+
+        public DraftApprenticeshipControllerTestFixture VerifyWhetherFrameworkCourseWereRequested(bool expectFrameworkCoursesToBeRequested)
+        {
+            _mediator
+                .Verify(m => m.Send(
+                    It.Is<GetTrainingCoursesQueryRequest>(request => request.IncludeFrameworks == expectFrameworkCoursesToBeRequested),
+                    It.IsAny<CancellationToken>()), 
+                 Times.Once);
             return this;
         }
     }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/WhenIAddADraftApprenticeshipToAnExistingCohort.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/WhenIAddADraftApprenticeshipToAnExistingCohort.cs
@@ -77,5 +77,14 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Controllers.DraftApprentices
                 .VerifyCohortDetailsWasCalledWithCorrectId()
                 .VerifyGetCoursesWasCalled();
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task FrameworkCourseAreOnlyRequestedWhenCohortisNotFundedByTransfer(bool isFundedByTransfer)
+        {
+            _fixture.SetupCohortTransferFundedStatus(isFundedByTransfer);
+            await _fixture.AddDraftApprenticeshipWithoutReservation();
+            _fixture.VerifyWhetherFrameworkCourseWereRequested(!isFundedByTransfer);
+        }
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/WhenIEditADraftApprenticeship.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/WhenIEditADraftApprenticeship.cs
@@ -67,5 +67,15 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Controllers.DraftApprentices
                 .VerifyCohortDetailsWasCalledWithCorrectId()
                 .VerifyGetCoursesWasCalled();
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task FrameworkCourseAreOnlyRequestedWhenCohortisNotFundedByTransfer(bool isFundedByTransfer)
+        {
+            _fixture.SetupCohortTransferFundedStatus(isFundedByTransfer);
+            await _fixture.AddDraftApprenticeshipWithoutReservation();
+            _fixture.VerifyWhetherFrameworkCourseWereRequested(!isFundedByTransfer);
+        }
+
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Controllers/DraftApprenticeshipController.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Controllers/DraftApprenticeshipController.cs
@@ -165,20 +165,16 @@ namespace SFA.DAS.ProviderCommitments.Web.Controllers
 
         private async Task AddLegalEntityAndCoursesToModel(DraftApprenticeshipViewModel model)
         {
-            var getCohortDetail = _providerCommitmentsService.GetCohortDetail(model.CohortId.Value);
-            var getCoursesTask = GetCourses();
-
-            await Task.WhenAll(getCohortDetail, getCoursesTask);
-
-            var cohortDetail = getCohortDetail.Result;
+            var cohortDetail = await _providerCommitmentsService.GetCohortDetail(model.CohortId.Value);
+            var courses = await GetCourses(cohortDetail);
 
             model.Employer = cohortDetail.LegalEntityName;
-            model.Courses = getCoursesTask.Result;
+            model.Courses = courses;
         }
 
-        private async Task<ICourse[]> GetCourses()
+        private async Task<ICourse[]> GetCourses(CohortDetails cohortDetails)
         {
-            var result = await _mediator.Send(new GetTrainingCoursesQueryRequest { IncludeFrameworks = true });
+            var result = await _mediator.Send(new GetTrainingCoursesQueryRequest { IncludeFrameworks = !cohortDetails.IsFundedByTransfer });
 
             return result.TrainingCourses;
         }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.8.0" />
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="4.2.12" />
     <PackageReference Include="SFA.DAS.Authorization.CommitmentPermissions" Version="4.3.52" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1479" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.1" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
@@ -23,9 +23,8 @@
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.8.0" />
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="4.2.12" />
     <PackageReference Include="SFA.DAS.Authorization.CommitmentPermissions" Version="4.3.52" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1479" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.1" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="SFA.DAS.ProviderUrlHelper" Version="1.1.687" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Models/CohortDetails.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Models/CohortDetails.cs
@@ -5,5 +5,6 @@
         public long CohortId { get; set; }
         public string HashedCohortId { get; set; }
         public string LegalEntityName { get; set; }
+        public bool IsFundedByTransfer { get; set; }
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.98" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.98" />
     <PackageReference Include="SFA.DAS.Authorization.ProviderPermissions" Version="4.3.52" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1479" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.98" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.98" />
     <PackageReference Include="SFA.DAS.Authorization.ProviderPermissions" Version="4.3.52" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1479" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1487" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1479" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Services/ProviderCommitmentsService.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Services/ProviderCommitmentsService.cs
@@ -28,7 +28,8 @@ namespace SFA.DAS.ProviderCommitments.Services
             {
                 CohortId = result.CohortId,
                 HashedCohortId = _hashingService.Encode(result.CohortId, EncodingType.CohortReference),
-                LegalEntityName = result.LegalEntityName
+                LegalEntityName = result.LegalEntityName,
+                IsFundedByTransfer = result.IsFundedByTransfer
             };
         }
 


### PR DESCRIPTION
Previously both standard and framework courses were available to all cohorts. This change prevents framework courses (which are considered legacy) from being available to transfer funded cohorts.