### PR TITLE
Cv 316 remove provider id from cohort method

### DIFF
--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared.UnitTests/CommitmentsServiceTests.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared.UnitTests/CommitmentsServiceTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Shared.Services;
+using SFA.DAS.CommitmentsV2.Api.Client;
+using SFA.DAS.CommitmentsV2.Api.Types.Responses;
+using SFA.DAS.CommitmentsV2.Types;
+using SFA.DAS.Encoding;
+
+namespace SFA.DAS.Commitments.Shared.UnitTests
+{
+    [TestFixture]
+    public class CommitmentsServiceTests
+    {
+        [Test]
+        public void Constructor_Valid_ShouldNotThrowException()
+        {
+            var fixtures = new CommitmentsServiceTestFixtures();
+
+            fixtures.CreateCommitmentsService();
+
+            Assert.Pass("Did not get an exception");
+        }
+
+        [Test]
+        public void Constructor_NullApiClient_ShouldShouldThrowNullArgumentException()
+        {
+            var fixtures = new CommitmentsServiceTestFixtures();
+
+            var ex = Assert.Throws<ArgumentNullException>(() =>fixtures.CreateCommitmentsServiceWithNullClient());
+            Assert.IsTrue(ex.Message.Contains("client", StringComparison.InvariantCultureIgnoreCase), ex.Message);
+        }
+
+        [Test]
+        public void Constructor_NullEncodingService_ShouldShouldThrowNullArgumentException()
+        {
+            var fixtures = new CommitmentsServiceTestFixtures();
+
+            var ex  = Assert.Throws<ArgumentNullException>(() => fixtures.CreateCommitmentsServiceWithNullEncodingService());
+            Assert.IsTrue(ex.Message.Contains("encodingservice", StringComparison.InvariantCultureIgnoreCase), ex.Message);
+        }
+    }
+
+    public class CommitmentsServiceTestFixtures
+    {
+        public CommitmentsServiceTestFixtures()
+        {
+            CommitmentsApiClientMock = new Mock<ICommitmentsApiClient>();    
+            EncodingServiceMock = new Mock<IEncodingService>();
+        }
+
+        public Mock<ICommitmentsApiClient> CommitmentsApiClientMock { get; }
+        public ICommitmentsApiClient CommitmentsApiClient => CommitmentsApiClientMock.Object;
+
+        public Mock<IEncodingService> EncodingServiceMock { get; }
+        public IEncodingService EncodingService => EncodingServiceMock.Object;
+
+        public CommitmentsService CreateCommitmentsService()
+        {
+            return new CommitmentsService(CommitmentsApiClient, EncodingService);
+        }
+
+        public CommitmentsService CreateCommitmentsServiceWithNullClient()
+        {
+            return new CommitmentsService(null, EncodingService);
+        }
+
+        public CommitmentsService CreateCommitmentsServiceWithNullEncodingService()
+        {
+            return new CommitmentsService(CommitmentsApiClient, null);
+        }
+
+        public CommitmentsServiceTestFixtures WithDraftApprenticeship(long cohortId, long draftApprenticeshipId)
+        {
+            CommitmentsApiClientMock
+                .Setup(cac =>
+                    cac.GetDraftApprenticeship(cohortId, draftApprenticeshipId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetDraftApprenticeshipResponse
+                {
+                    Id = draftApprenticeshipId
+                });
+
+            return this;
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared.UnitTests/SFA.DAS.Commitments.Shared.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared.UnitTests/SFA.DAS.Commitments.Shared.UnitTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="3.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared.UnitTests/SFA.DAS.Commitments.Shared.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared.UnitTests/SFA.DAS.Commitments.Shared.UnitTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Interfaces/ICommitmentsService.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Interfaces/ICommitmentsService.cs
@@ -2,6 +2,7 @@
 using SFA.DAS.Commitments.Shared.Models;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
 using SFA.DAS.CommitmentsV2.Api.Types.Responses;
+using SFA.DAS.CommitmentsV2.Types;
 
 namespace SFA.DAS.Commitments.Shared.Interfaces
 {
@@ -10,7 +11,7 @@ namespace SFA.DAS.Commitments.Shared.Interfaces
         Task AddDraftApprenticeshipToCohort(long cohortId, AddDraftApprenticeshipRequest request);
         Task<CreateCohortResponse> CreateCohort(CreateCohortRequest request);
         Task<CohortDetails> GetCohortDetail(long cohortId);
-        Task<EditDraftApprenticeshipDetails> GetDraftApprenticeshipForCohort(int providerId, long cohortId, long draftApprenticeshipId);
+        Task<EditDraftApprenticeshipDetails> GetDraftApprenticeshipForCohort(long cohortId, long draftApprenticeshipId);
         Task UpdateDraftApprenticeship(long cohortId, long draftApprenticeshipId, UpdateDraftApprenticeshipRequest updateRequest);
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Interfaces/ICommitmentsService.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Interfaces/ICommitmentsService.cs
@@ -1,13 +1,15 @@
 ﻿using System.Threading.Tasks;
 using SFA.DAS.Commitments.Shared.Models;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
+using SFA.DAS.CommitmentsV2.Api.Types.Responses;
 
 namespace SFA.DAS.Commitments.Shared.Interfaces
 {
     public interface ICommitmentsService
     {
-        Task<CohortDetails> GetCohortDetail(long cohortId);
         Task AddDraftApprenticeshipToCohort(long cohortId, AddDraftApprenticeshipRequest request);
+        Task<CreateCohortResponse> CreateCohort(CreateCohortRequest request);
+        Task<CohortDetails> GetCohortDetail(long cohortId);
         Task<EditDraftApprenticeshipDetails> GetDraftApprenticeshipForCohort(int providerId, long cohortId, long draftApprenticeshipId);
         Task UpdateDraftApprenticeship(long cohortId, long draftApprenticeshipId, UpdateDraftApprenticeshipRequest updateRequest);
     }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Models/CohortDetails.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Models/CohortDetails.cs
@@ -5,6 +5,7 @@
         public long CohortId { get; set; }
         public string HashedCohortId { get; set; }
         public string LegalEntityName { get; set; }
+        public string ProviderName { get; set; }
         public bool IsFundedByTransfer { get; set; }
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Models/EditDraftApprenticeshipDetails.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Models/EditDraftApprenticeshipDetails.cs
@@ -7,7 +7,8 @@ namespace SFA.DAS.Commitments.Shared.Models
         public long DraftApprenticeshipId { get; set; }
         public string DraftApprenticeshipHashedId { get; set; }
         public long CohortId { get; set; }
-        public int ProviderId { get; set; }
+        public long EmployerAccountId { get; set; }
+        public long ProviderId { get; set; }
         public string CohortReference { get; set; }
         public Guid? ReservationId { get; set; }
         public string FirstName { get; set; }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/SFA.DAS.Commitments.Shared.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/SFA.DAS.Commitments.Shared.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.199" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.199" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="3.0.5" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="StructureMap" Version="4.7.0" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/SFA.DAS.Commitments.Shared.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/SFA.DAS.Commitments.Shared.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.199" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.199" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="StructureMap" Version="4.7.0" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Services/CommitmentsService.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Services/CommitmentsService.cs
@@ -1,10 +1,12 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using SFA.DAS.Commitments.Shared.Interfaces;
 using SFA.DAS.Commitments.Shared.Models;
 using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
 using SFA.DAS.CommitmentsV2.Api.Types.Responses;
+using SFA.DAS.CommitmentsV2.Types;
 using SFA.DAS.Encoding;
 
 namespace SFA.DAS.Commitments.Shared.Services
@@ -12,12 +14,12 @@ namespace SFA.DAS.Commitments.Shared.Services
     public class CommitmentsService : ICommitmentsService
     {
         private readonly ICommitmentsApiClient _client;
-        private readonly IEncodingService _hashingService;
+        private readonly IEncodingService _encodingService;
 
-        public CommitmentsService(ICommitmentsApiClient client, IEncodingService hashingService)
+        public CommitmentsService(ICommitmentsApiClient client, IEncodingService encodingService)
         {
-            _client = client;
-            _hashingService = hashingService;
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _encodingService = encodingService ?? throw new ArgumentNullException(nameof(encodingService));
         }
 
         public async Task<CohortDetails> GetCohortDetail(long cohortId)
@@ -27,7 +29,7 @@ namespace SFA.DAS.Commitments.Shared.Services
             return new CohortDetails
             {
                 CohortId = result.CohortId,
-                HashedCohortId = _hashingService.Encode(result.CohortId, EncodingType.CohortReference),
+                HashedCohortId = _encodingService.Encode(result.CohortId, EncodingType.CohortReference),
                 LegalEntityName = result.LegalEntityName,
                 IsFundedByTransfer = result.IsFundedByTransfer
             };
@@ -43,17 +45,16 @@ namespace SFA.DAS.Commitments.Shared.Services
             return _client.CreateCohort(request, CancellationToken.None);
         }
 
-        public async Task<EditDraftApprenticeshipDetails> GetDraftApprenticeshipForCohort(int providerId, long cohortId, long draftApprenticeshipId)
+        public async Task<EditDraftApprenticeshipDetails> GetDraftApprenticeshipForCohort(long cohortId, long draftApprenticeshipId)
         {
             var result = await _client.GetDraftApprenticeship(cohortId, draftApprenticeshipId);
 
             return new EditDraftApprenticeshipDetails
             {
                 DraftApprenticeshipId = result.Id,
-                DraftApprenticeshipHashedId = _hashingService.Encode(result.Id, EncodingType.ApprenticeshipId),
+                DraftApprenticeshipHashedId = _encodingService.Encode(result.Id, EncodingType.ApprenticeshipId),
                 CohortId = cohortId,
-                ProviderId = providerId,
-                CohortReference = _hashingService.Encode(cohortId, EncodingType.CohortReference),
+                CohortReference = _encodingService.Encode(cohortId, EncodingType.CohortReference),
                 ReservationId = result.ReservationId,
                 FirstName = result.FirstName,
                 LastName = result.LastName,

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Services/CommitmentsService.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.Commitments.Shared/Services/CommitmentsService.cs
@@ -4,6 +4,7 @@ using SFA.DAS.Commitments.Shared.Interfaces;
 using SFA.DAS.Commitments.Shared.Models;
 using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
+using SFA.DAS.CommitmentsV2.Api.Types.Responses;
 using SFA.DAS.Encoding;
 
 namespace SFA.DAS.Commitments.Shared.Services
@@ -35,6 +36,11 @@ namespace SFA.DAS.Commitments.Shared.Services
         public Task AddDraftApprenticeshipToCohort(long cohortId, AddDraftApprenticeshipRequest request)
         {
             return _client.AddDraftApprenticeship(cohortId, request);
+        }
+
+        public Task<CreateCohortResponse> CreateCohort(CreateCohortRequest request)
+        {
+            return _client.CreateCohort(request, CancellationToken.None);
         }
 
         public async Task<EditDraftApprenticeshipDetails> GetDraftApprenticeshipForCohort(int providerId, long cohortId, long draftApprenticeshipId)

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="3.0.5" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="3.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="3.0.5" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="3.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/Services/ProviderCommitmentsServiceTests/WhenGettingADraftApprenticeship.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/Services/ProviderCommitmentsServiceTests/WhenGettingADraftApprenticeship.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
+using SFA.DAS.CommitmentsV2.Types;
 
 namespace SFA.DAS.ProviderCommitments.UnitTests.Services.ProviderCommitmentsServiceTests
 {
@@ -21,13 +22,11 @@ namespace SFA.DAS.ProviderCommitments.UnitTests.Services.ProviderCommitmentsServ
         [Test]
         public async Task ShouldMapValuesFromApiCallAndAddHashValues()
         {
-            var providerId = 1;
             var cohortId = 2;
             var apprenticeshipId = 123;
 
-            var result = await _fixture.Sut.GetDraftApprenticeshipForCohort(providerId, cohortId, apprenticeshipId);
+            var result = await _fixture.Sut.GetDraftApprenticeshipForCohort(cohortId, apprenticeshipId);
 
-            Assert.AreEqual(providerId, result.ProviderId);
             Assert.AreEqual(_fixture.GetDraftApprenticeshipResponse.Id, result.DraftApprenticeshipId);
             Assert.AreEqual(_fixture.GetDraftApprenticeshipResponse.FirstName, result.FirstName);
             Assert.AreEqual(_fixture.GetDraftApprenticeshipResponse.LastName, result.LastName);
@@ -47,7 +46,7 @@ namespace SFA.DAS.ProviderCommitments.UnitTests.Services.ProviderCommitmentsServ
         [Test]
         public async Task ShouldCallClientApiWithCorrectParameters()
         {
-            await _fixture.Sut.GetDraftApprenticeshipForCohort(1, 2, 123);
+            await _fixture.Sut.GetDraftApprenticeshipForCohort(2, 123);
 
             _fixture.CommitmentsApiClientMock.Verify(x => x.GetDraftApprenticeship(2, 123, It.IsAny<CancellationToken>()), Times.Once);
         }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/DraftApprenticeshipControllerTestFixture.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/DraftApprenticeshipControllerTestFixture.cs
@@ -11,6 +11,7 @@ using SFA.DAS.Commitments.Shared.Models;
 using SFA.DAS.Commitments.Shared.Models.ApprenticeshipCourse;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
 using SFA.DAS.CommitmentsV2.Api.Types.Validation;
+using SFA.DAS.CommitmentsV2.Types;
 using SFA.DAS.ProviderCommitments.Interfaces;
 using SFA.DAS.ProviderCommitments.Queries.GetTrainingCourses;
 using SFA.DAS.ProviderCommitments.Web.Controllers;
@@ -162,10 +163,16 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Controllers.DraftApprentices
             return this;
         }
 
+        public DraftApprenticeshipControllerTestFixture SetupProviderIdOnEditRequest(long providerId)
+        {
+            _editDraftApprenticeshipRequest.ProviderId = providerId;
+            return this;
+        }
+
         public DraftApprenticeshipControllerTestFixture SetupProviderCommitmentServiceToReturnADraftApprentice()
         {
             _providerCommitmentsService
-                .Setup(x => x.GetDraftApprenticeshipForCohort(It.IsAny<int>(), It.IsAny<long>(), It.IsAny<long>())).ReturnsAsync(_editDraftApprenticeshipDetails);
+                .Setup(x => x.GetDraftApprenticeshipForCohort(It.IsAny<long>(), It.IsAny<long>())).ReturnsAsync(_editDraftApprenticeshipDetails);
             return this;
         }
 
@@ -234,9 +241,18 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Controllers.DraftApprentices
             return this;
         }
 
+        public DraftApprenticeshipControllerTestFixture VerifyEditDraftApprenticeshipViewModelHasProviderIdSet()
+        {
+            Assert.IsInstanceOf<EditDraftApprenticeshipViewModel>(((ViewResult)_actionResult).Model);
+            var model = ((ViewResult)_actionResult).Model as EditDraftApprenticeshipViewModel;
+            Assert.AreEqual(_editDraftApprenticeshipRequest.ProviderId, model.ProviderId);
+
+            return this;
+        }
+
         public DraftApprenticeshipControllerTestFixture VerifyGetDraftApprenticeshipReceivesCorrectParameters()
         {
-            _providerCommitmentsService.Verify(x=>x.GetDraftApprenticeshipForCohort(_editDraftApprenticeshipRequest.ProviderId, _editDraftApprenticeshipRequest.CohortId.Value, _editDraftApprenticeshipRequest.DraftApprenticeshipId.Value));
+            _providerCommitmentsService.Verify(x=>x.GetDraftApprenticeshipForCohort(_editDraftApprenticeshipRequest.CohortId.Value, _editDraftApprenticeshipRequest.DraftApprenticeshipId.Value));
             return this;
         }
 

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/WhenIEditADraftApprenticeship.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Controllers/DraftApprenticeshipControllerTests/WhenIEditADraftApprenticeship.cs
@@ -23,6 +23,14 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Controllers.DraftApprentices
         }
 
         [Test]
+        public async Task ShouldSetProviderIdOnViewModel()
+        {
+            _fixture.SetupProviderCommitmentServiceToReturnADraftApprentice().SetupProviderIdOnEditRequest(123);
+            await _fixture.EditDraftApprenticeship();
+            _fixture.VerifyEditDraftApprenticeshipViewModelHasProviderIdSet();
+        }
+
+        [Test]
         public async Task ShouldPassCohortIdAndDraftApprenticeshipIdToGetDraftApprenticeshipOnProviderCommitmentsService()
         {
             _fixture.SetupProviderCommitmentServiceToReturnADraftApprentice();

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
   </ItemGroup>
 

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="3.0.5" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="3.0.5" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
   </ItemGroup>
 

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Controllers/DraftApprenticeshipController.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Controllers/DraftApprenticeshipController.cs
@@ -11,6 +11,7 @@ using SFA.DAS.Commitments.Shared.Models;
 using SFA.DAS.Commitments.Shared.Models.ApprenticeshipCourse;
 using SFA.DAS.CommitmentsV2.Api.Types.Requests;
 using SFA.DAS.CommitmentsV2.Api.Types.Validation;
+using SFA.DAS.CommitmentsV2.Types;
 using SFA.DAS.ProviderCommitments.Features;
 using SFA.DAS.ProviderCommitments.Queries.GetTrainingCourses;
 using SFA.DAS.ProviderCommitments.Web.Attributes;
@@ -131,9 +132,10 @@ namespace SFA.DAS.ProviderCommitments.Web.Controllers
 
             var model = _editDraftApprenticeshipDetailsToViewModelMapper.Map(
                 await _commitmentsService.GetDraftApprenticeshipForCohort(
-                    request.ProviderId,
                     request.CohortId.Value,
                     request.DraftApprenticeshipId.Value));
+
+            model.ProviderId = request.ProviderId;
 
             await AddLegalEntityAndCoursesToModel(model);
 

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/CommitmentsApiRegistry.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/DependencyResolution/CommitmentsApiRegistry.cs
@@ -1,4 +1,5 @@
-﻿using SFA.DAS.CommitmentsV2.Api.Client;
+﻿using Microsoft.Extensions.Logging;
+using SFA.DAS.CommitmentsV2.Api.Client;
 using SFA.DAS.CommitmentsV2.Api.Client.Configuration;
 using SFA.DAS.CommitmentsV2.Api.Client.DependencyResolution;
 using StructureMap;
@@ -14,7 +15,8 @@ namespace SFA.DAS.ProviderCommitments.Web.DependencyResolution
             For<ICommitmentsApiClientFactory>().Use("", x =>
             {
                 var config = x.GetInstance<CommitmentsClientApiConfiguration>();
-                return new CommitmentsApiClientFactory(config);
+                var loggerFactory = x.GetInstance<ILoggerFactory>();
+                return new CommitmentsApiClientFactory(config, loggerFactory);
             }).Singleton();
         }
     }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Models/DraftApprenticeshipViewModel.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Models/DraftApprenticeshipViewModel.cs
@@ -22,7 +22,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Models
             EndDate = new MonthYearModel("");
         }
 
-        public int ProviderId { get; set; }
+        public long ProviderId { get; set; }
         public string CohortReference { get; set; }
         public long? CohortId { get; set; }
 

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Requests/EditDraftApprenticeshipRequest.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Requests/EditDraftApprenticeshipRequest.cs
@@ -4,7 +4,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Requests
 {
     public class EditDraftApprenticeshipRequest : IAuthorizationContextModel
     {
-        public int ProviderId { get; set; }
+        public long ProviderId { get; set; }
         public long? CohortId { get; set; }
 
         public string CohortReference { get; set; }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="5.3.5" />
     <PackageReference Include="SFA.DAS.Authorization.ProviderFeatures" Version="5.3.5" />
     <PackageReference Include="SFA.DAS.Authorization.CommitmentPermissions" Version="5.3.5" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="3.0.5" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="3.0.5" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="SFA.DAS.Provider.Shared.UI" Version="1.1.5" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="5.3.5" />
     <PackageReference Include="SFA.DAS.Authorization.ProviderFeatures" Version="5.3.5" />
     <PackageReference Include="SFA.DAS.Authorization.CommitmentPermissions" Version="5.3.5" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="SFA.DAS.Provider.Shared.UI" Version="1.1.5" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Application/Commands/CreateCohort/CreateCohortRequest.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Application/Commands/CreateCohort/CreateCohortRequest.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.ProviderCommitments.Application.Commands.CreateCohort
     {
         public string UserId { get; set; }
         public long AccountLegalEntityId { get; set; }
-        public int ProviderId { get; set; }
+        public long ProviderId { get; set; }
         public Guid ReservationId { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.199" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.199" />
     <PackageReference Include="SFA.DAS.Authorization.ProviderPermissions" Version="5.3.5" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="3.0.5" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="3.0.5" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.199" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.199" />
     <PackageReference Include="SFA.DAS.Authorization.ProviderPermissions" Version="5.3.5" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1507" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1507" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="2.1.1527" />
+    <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Types" Version="2.1.1527" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />


### PR DESCRIPTION
The purpose of this change is to make the CommitmentsService employer/provider agnostic by removing the provider id from the GetDraftApprenticeshipForCohort method. 
As part of this there have been some small re-factorings, including specifying provider id as a long rather than an int to reflect the underlying type. The API nuget package was updated, which has added an additional parameter to the client factory. 