### PR TITLE
simplify nuget dependencies

### DIFF
--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.IntegrationTests/SFA.DAS.ProviderCommitments.IntegrationTests.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="4.1.797" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Types" Version="4.1.797" />
     <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.165" />
   </ItemGroup>
 

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/SFA.DAS.ProviderCommitments.UnitTests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="4.1.797" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Types" Version="4.1.797" />
     <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.165" />
   </ItemGroup>
 

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/SFA.DAS.ProviderCommitments.Web.UnitTests.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="4.1.797" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Types" Version="4.1.797" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
     <PackageReference Include="SFA.DAS.Testing" Version="3.0.22" />
     <PackageReference Include="SFA.DAS.Testing.AutoFixture" Version="3.0.165" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="SFA.DAS.Authorization.CommitmentPermissions" Version="6.0.49" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="4.1.797" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Shared" Version="4.1.797" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Types" Version="4.1.797" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="SFA.DAS.Provider.Shared.UI" Version="1.1.9" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="SFA.DAS.Authorization.ProviderPermissions" Version="6.0.49" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="4.1.797" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Shared" Version="4.1.797" />
-    <PackageReference Include="SFA.DAS.CommitmentsV2.Types" Version="4.1.797" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.1" />
     <PackageReference Include="SFA.DAS.ProviderRelationships.Api.Client" Version="3.2.61" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />


### PR DESCRIPTION
Currently updating the api nuget causes conflicts if you haven't already updated the api types nuget first. As the api types nuget is already used by the api client nuget then it isn't necessary to explicitly depend on the api types nuget.