### PR TITLE
[CON-4120] Use route configuration as the Structure map initialisatio…

### DIFF
--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Extensions/DataProtectionStartupExtensions.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Extensions/DataProtectionStartupExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using SFA.DAS.ProviderCommitments.Configuration;
 using StackExchange.Redis;
@@ -8,11 +9,11 @@ namespace SFA.DAS.ProviderCommitments.Web.Extensions
 {
     public static class DataProtectionStartupExtensions
     {
-        public static IServiceCollection AddDataProtection(this IServiceCollection services, IHostingEnvironment environment)
+        public static IServiceCollection AddDataProtection(this IServiceCollection services, IConfiguration configuration, IHostingEnvironment environment)
         {
             if (!environment.IsDevelopment())
             {
-                var config = services.BuildServiceProvider().GetService<DataProtectionConnectionStrings>();
+                var config = configuration.GetSection(ProviderCommitmentsConfigurationKeys.DataProtectionConnectionStrings).Get<DataProtectionConnectionStrings>();
 
                 if (config != null)
                 {

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Startup.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Startup.cs
@@ -36,7 +36,7 @@ namespace SFA.DAS.ProviderCommitments.Web
         public IConfiguration Configuration { get; }
         public IHostingEnvironment Environment { get; }
 
-        // This method gets called by the runtime. Use this method to add services to the container.
+        // This method gets called by the runtime. Use this method to add services to the container.    
         public void ConfigureServices(IServiceCollection services)
         {
             services
@@ -70,7 +70,7 @@ namespace SFA.DAS.ProviderCommitments.Web
 
             services
                 .AddAuthorizationService()
-                .AddDataProtection(Environment)
+                .AddDataProtection(Configuration, Environment)
                 .AddUrlHelper()
                 .AddHealthChecks();
 


### PR DESCRIPTION
…n which registeres the DataProtectionConnectionStrings object is not run until after ConfigureServices().

This has resulted in ongoing issues with the DataProtectionKeys resulting in the error:
"key {keyId} could not be found in the key ring"