### PR TITLE
Create shut out page for Provider Commitments who aren't allowed access to PAS

### DIFF
--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/Infrastructure/OuterApi/OuterApiServiceTest.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/Infrastructure/OuterApi/OuterApiServiceTest.cs
@@ -1,0 +1,36 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi;
+using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Requests.Provider;
+using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Responses;
+using SFA.DAS.Testing.AutoFixture;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ProviderCommitments.UnitTests.Infrastructure.OuterApi
+{
+    public class OuterApiServiceTest
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_Request_Is_Made_And_ProviderResponse_Returned(
+            long ukprn,
+            ProviderAccountResponse apiResponse,
+            [Frozen] Mock<IOuterApiClient> apiClient,
+            OuterApiService service)
+        {
+            //Arrange
+            var request = new GetProviderStatusDetails(ukprn);
+            apiClient.Setup(x =>
+                    x.Get<ProviderAccountResponse>(
+                        It.Is<GetProviderStatusDetails>(c => c.GetUrl.Equals(request.GetUrl))))
+                .ReturnsAsync(apiResponse);
+
+            //Act
+            var actual = await service.GetProviderStatus(ukprn);
+
+            //Assert
+            actual.CanAccessService.Should().Be(apiResponse.CanAccessService);
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/Infrastructure/OuterApi/Requests/Provider/WhenBuildingGetProviderAccountRequest.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.UnitTests/Infrastructure/OuterApi/Requests/Provider/WhenBuildingGetProviderAccountRequest.cs
@@ -1,0 +1,18 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Requests.Provider;
+
+namespace SFA.DAS.ProviderCommitments.UnitTests.Infrastructure.OuterApi.Requests.Provider
+{
+    public class WhenBuildingGetProviderAccountRequest
+    {
+        [Test, AutoData]
+        public void Then_The_Url_Is_Correctly_Constructed(int ukprn)
+        {
+            var actual = new GetProviderStatusDetails(ukprn);
+
+            actual.GetUrl.Should().Be($"provideraccounts/{ukprn}");
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Authorization/WhenHandlingTrainingProviderAllRolesRequirement.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Authorization/WhenHandlingTrainingProviderAllRolesRequirement.cs
@@ -81,7 +81,7 @@ namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Authorization
 
             //Assert
             context.HasSucceeded.Should().BeTrue();
-            httpResponse.Verify(x => x.Redirect(It.Is<string>(c => c.Contains("/error/401"))));
+            httpResponse.Verify(x => x.Redirect(It.Is<string>(c => c.Contains("/error/403/invalid-status"))));
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Authorization/WhenHandlingTrainingProviderAllRolesRequirement.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Authorization/WhenHandlingTrainingProviderAllRolesRequirement.cs
@@ -1,0 +1,110 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Responses;
+using SFA.DAS.ProviderCommitments.Web.Authentication;
+using SFA.DAS.ProviderCommitments.Web.Authorization;
+using SFA.DAS.Testing.AutoFixture;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Authorization
+{
+    public class WhenHandlingTrainingProviderAllRolesRequirement
+    {
+        [Test, MoqAutoData]
+        public async Task Then_Fails_If_No_Provider_Ukprn_Claim(
+        int ukprn,
+        TrainingProviderAllRolesRequirement providerRequirement,
+        TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var claim = new Claim("NotProviderClaim", ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, null);
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            Assert.IsFalse(context.HasSucceeded);
+            Assert.IsTrue(context.HasFailed);
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Fails_If_Non_Numeric_Provider_Ukprn_Claim(
+            string ukprn,
+            TrainingProviderAllRolesRequirement providerRequirement,
+            TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var claim = new Claim(ProviderClaims.Ukprn, ukprn);
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, null);
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            Assert.IsFalse(context.HasSucceeded);
+            Assert.IsTrue(context.HasFailed);
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Fails_If_Provider_Ukprn_Claim_Response_Is_False(
+            int ukprn,
+            TrainingProviderAllRolesRequirement providerRequirement,
+            [Frozen] Mock<ITrainingProviderAuthorizationHandler> trainingProviderAuthorizationHandler,
+            TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var httpContextBase = new Mock<HttpContext>();
+            var httpResponse = new Mock<HttpResponse>();
+            httpContextBase.Setup(c => c.Response).Returns(httpResponse.Object);
+            var filterContext = new AuthorizationFilterContext(new ActionContext(httpContextBase.Object, new RouteData(), new ActionDescriptor()), new List<IFilterMetadata>());
+            var claim = new Claim(ProviderClaims.Ukprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, filterContext);
+            var response = new ProviderAccountResponse { CanAccessService = false };
+            trainingProviderAuthorizationHandler.Setup(x => x.IsProviderAuthorized(context)).ReturnsAsync(response.CanAccessService);
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            context.HasSucceeded.Should().BeTrue();
+            httpResponse.Verify(x => x.Redirect(It.Is<string>(c => c.Contains("/error/401"))));
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Succeeds_If_Provider_Ukprn_Claim_Response_Is_True(
+            int ukprn,
+            TrainingProviderAllRolesRequirement providerRequirement,
+            [Frozen] Mock<ITrainingProviderAuthorizationHandler> trainingProviderAuthorizationHandler,
+            TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var claim = new Claim(ProviderClaims.Ukprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, null);
+            var response = new ProviderAccountResponse { CanAccessService = false };
+            trainingProviderAuthorizationHandler.Setup(x => x.IsProviderAuthorized(context)).ReturnsAsync(response.CanAccessService);
+
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            Assert.IsTrue(context.HasSucceeded);
+            Assert.IsFalse(context.HasFailed);
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Authorization/WhenHandlingTrainingProviderAuthorization.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web.UnitTests/Authorization/WhenHandlingTrainingProviderAuthorization.cs
@@ -1,0 +1,98 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Responses;
+using SFA.DAS.ProviderCommitments.Interfaces;
+using SFA.DAS.ProviderCommitments.Web.Authentication;
+using SFA.DAS.ProviderCommitments.Web.Authorization;
+using SFA.DAS.Testing.AutoFixture;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ProviderCommitments.Web.UnitTests.Authorization
+{
+    public class WhenHandlingTrainingProviderAuthorization
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_ProviderStatus_Is_Valid_And_True_Returned(
+            long ukprn,
+            ProviderAccountResponse apiResponse,
+            [Frozen] Mock<IOuterApiService> outerApiService,
+            [Frozen] Mock<IHttpContextAccessor> httpContextAccessor,
+            TrainingProviderAllRolesRequirement requirement,
+            TrainingProviderAuthorizationHandler handler)
+        {
+            //Arrange
+            apiResponse.CanAccessService = true;
+            var claim = new Claim(ProviderClaims.Ukprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { requirement }, claimsPrinciple, null);
+            var responseMock = new FeatureCollection();
+            var httpContext = new DefaultHttpContext(responseMock);
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+
+            outerApiService.Setup(x => x.GetProviderStatus(ukprn)).ReturnsAsync(apiResponse);
+
+            //Act
+            var actual = await handler.IsProviderAuthorized(context);
+
+            //Assert
+            actual.Should().BeTrue();
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_ProviderDetails_Is_InValid_And_False_Returned(
+            long ukprn,
+            ProviderAccountResponse apiResponse,
+            [Frozen] Mock<IOuterApiService> outerApiService,
+            [Frozen] Mock<IHttpContextAccessor> httpContextAccessor,
+            TrainingProviderAllRolesRequirement requirement,
+            TrainingProviderAuthorizationHandler handler)
+        {
+            //Arrange
+            apiResponse.CanAccessService = false;
+            var claim = new Claim(ProviderClaims.Ukprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { requirement }, claimsPrinciple, null);
+            var responseMock = new FeatureCollection();
+            var httpContext = new DefaultHttpContext(responseMock);
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            outerApiService.Setup(x => x.GetProviderStatus(ukprn)).ReturnsAsync(apiResponse);
+
+            //Act
+            var actual = await handler.IsProviderAuthorized(context);
+
+            //Assert
+            actual.Should().BeFalse();
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_ProviderDetails_Is_Null_And_False_Returned(
+            long ukprn,
+            [Frozen] Mock<IOuterApiService> outerApiService,
+            [Frozen] Mock<IHttpContextAccessor> httpContextAccessor,
+            TrainingProviderAllRolesRequirement requirement,
+            TrainingProviderAuthorizationHandler handler)
+        {
+            //Arrange
+            var claim = new Claim(ProviderClaims.Ukprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { requirement }, claimsPrinciple, null);
+            var responseMock = new FeatureCollection();
+            var httpContext = new DefaultHttpContext(responseMock);
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            outerApiService.Setup(x => x.GetProviderStatus(ukprn)).ReturnsAsync((ProviderAccountResponse)null!);
+
+            //Act
+            var actual = await handler.IsProviderAuthorized(context);
+
+            //Assert
+            actual.Should().BeFalse();
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authentication/AuthenticationExtensions.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authentication/AuthenticationExtensions.cs
@@ -11,13 +11,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SFA.DAS.DfESignIn.Auth.AppStart;
+using SFA.DAS.DfESignIn.Auth.Enums;
 using SFA.DAS.ProviderCommitments.Configuration;
 
 namespace SFA.DAS.ProviderCommitments.Web.Authentication
 {
     public static class AuthenticationExtensions
     {
-        private const string ClientName = "ProviderRoATP";
         private const string CookieAuthName = "SFA.DAS.ProviderApprenticeshipService";
 
         public static IServiceCollection AddProviderAuthentication(this IServiceCollection services, IConfiguration config)
@@ -35,7 +35,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Authentication
                         config,
                         CookieAuthName,
                         typeof(CustomServiceRole),
-                        ClientName,
+                        ClientName.ProviderRoatp,
                         "/signout",
                         "");
                 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/AuthorizationPolicyBuilderExtensions.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/AuthorizationPolicyBuilderExtensions.cs
@@ -17,6 +17,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
                     policy.RequireClaim(ProviderClaims.Service);
                     policy.RequireClaim(ProviderClaims.Ukprn);
                     policy.Requirements.Add(new ProviderRequirement());
+                    policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                 });
 
                 options.AddPolicy(PolicyNames.HasViewerOrAbovePermission, policy =>
@@ -25,6 +26,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
                     policy.RequireClaim(ProviderClaims.Service);
                     policy.RequireClaim(ProviderClaims.Ukprn);
                     policy.Requirements.Add(new MinimumServiceClaimRequirement(ServiceClaim.DAV));
+                    policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                 });
 
                 options.AddPolicy(PolicyNames.HasContributorOrAbovePermission, policy =>
@@ -33,6 +35,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
                     policy.RequireClaim(ProviderClaims.Service);
                     policy.RequireClaim(ProviderClaims.Ukprn);
                     policy.Requirements.Add(new MinimumServiceClaimRequirement(ServiceClaim.DAC));
+                    policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                 });
 
                 options.AddPolicy(PolicyNames.HasContributorWithApprovalOrAbovePermission, policy =>
@@ -41,6 +44,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
                     policy.RequireClaim(ProviderClaims.Service);
                     policy.RequireClaim(ProviderClaims.Ukprn);
                     policy.Requirements.Add(new MinimumServiceClaimRequirement(ServiceClaim.DAB));
+                    policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                 });
 
                 options.AddPolicy(PolicyNames.HasAccountOwnerPermission, policy =>
@@ -49,12 +53,15 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
                     policy.RequireClaim(ProviderClaims.Service);
                     policy.RequireClaim(ProviderClaims.Ukprn);
                     policy.Requirements.Add(new MinimumServiceClaimRequirement(ServiceClaim.DAA));
+                    policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                 });
             });
 
             services.AddTransient<IActionContextAccessor, ActionContextAccessor>();
             services.AddTransient<IAuthorizationHandler, ProviderHandler>();
             services.AddTransient<IAuthorizationHandler, MinimumServiceClaimRequirementHandler>();
+            services.AddSingleton<ITrainingProviderAuthorizationHandler, TrainingProviderAuthorizationHandler>();
+            services.AddSingleton<IAuthorizationHandler, TrainingProviderAllRolesAuthorizationHandler>();
 
             return services;
         }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAllRolesAuthorizationHandler.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAllRolesAuthorizationHandler.cs
@@ -60,7 +60,7 @@ namespace SFA.DAS.ProviderCommitments.Web.Authorization
             // logic to check if the provider is authorized if not redirect the user to PAS 401 un-authorized page.
             if (!isStubProviderValidationEnabled && !(await _handler.IsProviderAuthorized(context)))
             {
-                currentContext?.Response.Redirect($"{_providerSharedUiConfiguration.DashboardUrl}/error/401");
+                currentContext?.Response.Redirect($"{_providerSharedUiConfiguration.DashboardUrl}/error/403/invalid-status");
             }
 
             context.Succeed(requirement);

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAllRolesAuthorizationHandler.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAllRolesAuthorizationHandler.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using SFA.DAS.Provider.Shared.UI.Models;
+using System.Threading.Tasks;
+using SFA.DAS.ProviderCommitments.Web.Authentication;
+
+namespace SFA.DAS.ProviderCommitments.Web.Authorization
+{
+    public class TrainingProviderAllRolesAuthorizationHandler : AuthorizationHandler<TrainingProviderAllRolesRequirement>
+    {
+        private readonly ITrainingProviderAuthorizationHandler _handler;
+        private readonly IConfiguration _configuration;
+        private readonly ProviderSharedUIConfiguration _providerSharedUiConfiguration;
+
+        public TrainingProviderAllRolesAuthorizationHandler(
+            ITrainingProviderAuthorizationHandler handler,
+            IConfiguration configuration,
+            ProviderSharedUIConfiguration providerSharedUiConfiguration)
+        {
+            _handler = handler;
+            _providerSharedUiConfiguration = providerSharedUiConfiguration;
+            _configuration = configuration;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, TrainingProviderAllRolesRequirement requirement)
+        {
+            HttpContext currentContext;
+            switch (context.Resource)
+            {
+                case HttpContext resource:
+                    currentContext = resource;
+                    break;
+                case AuthorizationFilterContext authorizationFilterContext:
+                    currentContext = authorizationFilterContext.HttpContext;
+                    break;
+                default:
+                    currentContext = null;
+                    break;
+            }
+
+            if (!context.User.HasClaim(c => c.Type.Equals(ProviderClaims.Ukprn)))
+            {
+                context.Fail();
+                return;
+            }
+
+            var claimValue = context.User.FindFirst(c => c.Type.Equals(ProviderClaims.Ukprn)).Value;
+
+            if (!int.TryParse(claimValue, out var ukprn))
+            {
+                context.Fail();
+                return;
+            }
+
+            var isStubProviderValidationEnabled = GetUseStubProviderValidationSetting();
+
+            // check if the stub is activated to by-pass the validation. Mostly used for local development purpose.
+            // logic to check if the provider is authorized if not redirect the user to PAS 401 un-authorized page.
+            if (!isStubProviderValidationEnabled && !(await _handler.IsProviderAuthorized(context)))
+            {
+                currentContext?.Response.Redirect($"{_providerSharedUiConfiguration.DashboardUrl}/error/401");
+            }
+
+            context.Succeed(requirement);
+        }
+
+        private bool GetUseStubProviderValidationSetting()
+        {
+            var value = _configuration.GetSection("UseStubProviderValidation").Value;
+
+            return value != null && bool.TryParse(value, out var result) && result;
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAllRolesRequirement.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAllRolesRequirement.cs
@@ -1,0 +1,6 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace SFA.DAS.ProviderCommitments.Web.Authorization
+{
+    public class TrainingProviderAllRolesRequirement : IAuthorizationRequirement { }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAuthorizationHandler.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Authorization/TrainingProviderAuthorizationHandler.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+using SFA.DAS.ProviderCommitments.Interfaces;
+using SFA.DAS.ProviderCommitments.Web.Authentication;
+
+namespace SFA.DAS.ProviderCommitments.Web.Authorization
+{
+    /// <summary>
+    /// Interface to define contracts related to Training Provider Authorization Handlers.
+    /// </summary>
+    public interface ITrainingProviderAuthorizationHandler
+    {
+        /// <summary>
+        /// Contract to check is the logged in Provider is a valid Training Provider. 
+        /// </summary>
+        /// <param name="context">AuthorizationHandlerContext.</param>
+        /// <returns>boolean.</returns>
+        Task<bool> IsProviderAuthorized(AuthorizationHandlerContext context);
+    }
+
+    ///<inheritdoc cref="ITrainingProviderAuthorizationHandler"/>
+    public class TrainingProviderAuthorizationHandler : ITrainingProviderAuthorizationHandler
+    {
+        private readonly IOuterApiService _outerApiService;
+
+        public TrainingProviderAuthorizationHandler(
+            IOuterApiService outerApiService)
+        {
+            _outerApiService = outerApiService;
+        }
+
+        public async Task<bool> IsProviderAuthorized(AuthorizationHandlerContext context)
+        {
+            var ukprn = GetProviderId(context);
+
+            //if the ukprn is invalid return false.
+            if (ukprn <= 0) return false;
+
+            var providerStatusDetails = await _outerApiService.GetProviderStatus(ukprn);
+
+            // Condition to check if the Provider Details has permission to access Apprenticeship Services based on the property value "CanAccessApprenticeshipService" set to True.
+            return providerStatusDetails is { CanAccessService: true };
+        }
+
+        private static long GetProviderId(AuthorizationHandlerContext context)
+        {
+            return long.TryParse(context.User.FindFirst(c => c.Type.Equals(ProviderClaims.Ukprn))?.Value, out var providerId)
+                ? providerId
+                : 0;
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/SFA.DAS.ProviderCommitments.Web.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="SFA.DAS.Authorization.ProviderFeatures" Version="6.0.97" />
     <PackageReference Include="SFA.DAS.Authorization.CommitmentPermissions" Version="6.0.97" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
-    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.61" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.63" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.2.1" />
     <PackageReference Include="SFA.DAS.PAS.Account.Api.ClientV2" Version="17267.0.542" />
     <PackageReference Include="SFA.DAS.Provider.Shared.UI" Version="2.0.27" />

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/appsettings.json
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/appsettings.json
@@ -10,6 +10,7 @@
   },
   "UseStubProviderRelationships": true,
   "UseStubProviderAuth": true,
+  "UseStubProviderValidation": false,
   "UseLocalRegistry": true,
   "ResourceEnvironmentName": "LOCAL"
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/IOuterApiService.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/IOuterApiService.cs
@@ -29,5 +29,11 @@ namespace SFA.DAS.ProviderCommitments.Interfaces
         Task<CreatePriorLearningDataResponse> UpdatePriorLearningData(long providerId, long cohortId, long draftApprenticeshipId, CreatePriorLearningDataRequest request);
         Task<GetPriorLearningSummaryQueryResult> GetPriorLearningSummary(long providerId, long cohortId, long apprenticeshipId);
         Task<GetCohortDetailsResponse> GetCohortDetails(long providerId, long cohortId);
+        /// <summary>
+        /// CONTRACT TO GET THE PROVIDER STATUS FROM THE OUTER API.
+        /// </summary>
+        /// <param name="ukprn">provider id or ukprn.</param>
+        /// <returns>ProviderAccountResponse</returns>
+        Task<ProviderAccountResponse> GetProviderStatus(long ukprn);
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/OuterApiService.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/OuterApiService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Requests.Cohorts;
 using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Requests.DraftApprenticeship;
+using SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Requests.Provider;
 
 namespace SFA.DAS.ProviderCommitments.Infrastructure.OuterApi
 {
@@ -105,6 +106,12 @@ namespace SFA.DAS.ProviderCommitments.Infrastructure.OuterApi
         public async Task<GetCohortDetailsResponse> GetCohortDetails(long providerId, long cohortId)
         {
             return await _outerApiClient.Get<GetCohortDetailsResponse>(new GetCohortDetailsRequest(providerId, cohortId));
+        }
+
+        // <inherit-doc />
+        public async Task<ProviderAccountResponse> GetProviderStatus(long ukprn)
+        {
+            return await _outerApiClient.Get<ProviderAccountResponse>(new GetProviderStatusDetails(ukprn));
         }
     }
 }

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/Requests/Provider/GetProviderStatusDetails.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/Requests/Provider/GetProviderStatusDetails.cs
@@ -1,0 +1,14 @@
+﻿namespace SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Requests.Provider
+{
+    public class GetProviderStatusDetails : IGetApiRequest
+    {
+        private readonly long _ukprn;
+
+        public GetProviderStatusDetails(long ukprn)
+        {
+            _ukprn = ukprn;
+        }
+
+        public string GetUrl => $"provideraccounts/{_ukprn}";
+    }
+}

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/Responses/ProviderAccountResponse.cs
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments/Infrastructure/OuterApi/Responses/ProviderAccountResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SFA.DAS.ProviderCommitments.Infrastructure.OuterApi.Responses
+{
+    public class ProviderAccountResponse
+    {
+        [JsonPropertyName("canAccessService")]
+        public bool CanAccessService { get; set; }
+    }
+}


### PR DESCRIPTION
Commit Details:
Added new Requirement to the Policy to check if the Provider is valid one.

Condition 1: is the provider's profile a Main or Employer Profile.
Condition 2: is the provider's status Active or On-boarding.

Story: https://skillsfundingagency.atlassian.net/browse/FAI-949