### PR TITLE
FLP-975 DraftApprenticeship Help Text changes

### DIFF
--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Views/Shared/DraftApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Views/Shared/DraftApprenticeship.cshtml
@@ -230,7 +230,7 @@ else
     </dl>
 }
 
-<h1 class="govuk-heading-l  govuk-!-margin-top-9">Apprentice training details</h1>
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Apprentice training dates</h2>
 
 @if (Model.IsOnFlexiPaymentPilot.HasValue && Model.IsOnFlexiPaymentPilot.Value)
 {
@@ -362,6 +362,31 @@ else
         </fieldset>
     </div>
 }
+
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Apprenticeship price</h2>
+
+<p class="govuk-body">
+    The total apprenticeship price covers training and end-point assessment costs, calculated automatically from your figures.
+</p>
+
+<details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+            What to do if you don't know the end-point assessment price
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+        <p>
+            If you haven't selected an end-point assessment organisation (EPAO) or finalised the contract, you can enter a nominal value of £1 for the end-point assessment.
+            <br />
+            Adjust the training price to reflect this. For example, if training costs £9,000, enter £8,999 for training and £1 for the end-point assessment.
+            <br />
+            You can update both prices during the apprenticeship once the end-point assessment price is confirmed.
+            <br />
+            Any increase in the total price will need employer approval.
+        </p>
+    </div>
+</details>
 
 @if (Model.IsOnFlexiPaymentPilot.HasValue && Model.IsOnFlexiPaymentPilot.Value)
 {

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Views/Shared/DraftApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Views/Shared/DraftApprenticeship.cshtml
@@ -230,7 +230,7 @@ else
     </dl>
 }
 
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Apprentice training dates</h2>
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Apprenticeship training dates</h2>
 
 @if (Model.IsOnFlexiPaymentPilot.HasValue && Model.IsOnFlexiPaymentPilot.Value)
 {
@@ -378,11 +378,11 @@ else
     <div class="govuk-details__text">
         <p>
             If you haven't selected an end-point assessment organisation (EPAO) or finalised the contract, you can enter a nominal value of £1 for the end-point assessment.
-            <br />
+            <br /><br />
             Adjust the training price to reflect this. For example, if training costs £9,000, enter £8,999 for training and £1 for the end-point assessment.
-            <br />
+            <br /><br />
             You can update both prices during the apprenticeship once the end-point assessment price is confirmed.
-            <br />
+            <br /><br />
             Any increase in the total price will need employer approval.
         </p>
     </div>

--- a/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Views/Shared/DraftApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderCommitments/SFA.DAS.ProviderCommitments.Web/Views/Shared/DraftApprenticeship.cshtml
@@ -230,10 +230,10 @@ else
     </dl>
 }
 
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Apprenticeship training dates</h2>
-
 @if (Model.IsOnFlexiPaymentPilot.HasValue && Model.IsOnFlexiPaymentPilot.Value)
 {
+    <h2 class="govuk-heading-l govuk-!-margin-top-9">Apprenticeship training dates</h2>
+
     <div id="actual-start-date-section" class="govuk-form-group  @Html.AddClassIfPropertyInError(x => x.ActualStartDate, "govuk-form-group--error")">
         <fieldset class="govuk-fieldset" aria-describedby="actual-start-date-hint" role="group">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -271,6 +271,8 @@ else
 }
 else
 {
+    <h1 class="govuk-heading-l  govuk-!-margin-top-9">Apprentice training details</h1>
+
     <div id="start-date-section" class="govuk-form-group  @Html.AddClassIfPropertyInError(x => x.StartDate, "govuk-form-group--error")">
         <fieldset class="govuk-fieldset" aria-describedby="start-date-hint" role="group">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -363,33 +365,33 @@ else
     </div>
 }
 
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Apprenticeship price</h2>
-
-<p class="govuk-body">
-    The total apprenticeship price covers training and end-point assessment costs, calculated automatically from your figures.
-</p>
-
-<details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-            What to do if you don't know the end-point assessment price
-        </span>
-    </summary>
-    <div class="govuk-details__text">
-        <p>
-            If you haven't selected an end-point assessment organisation (EPAO) or finalised the contract, you can enter a nominal value of £1 for the end-point assessment.
-            <br /><br />
-            Adjust the training price to reflect this. For example, if training costs £9,000, enter £8,999 for training and £1 for the end-point assessment.
-            <br /><br />
-            You can update both prices during the apprenticeship once the end-point assessment price is confirmed.
-            <br /><br />
-            Any increase in the total price will need employer approval.
-        </p>
-    </div>
-</details>
-
 @if (Model.IsOnFlexiPaymentPilot.HasValue && Model.IsOnFlexiPaymentPilot.Value)
 {
+    <h2 class="govuk-heading-l govuk-!-margin-top-9">Apprenticeship price</h2>
+
+    <p class="govuk-body">
+        The total apprenticeship price covers training and end-point assessment costs, calculated automatically from your figures.
+    </p>
+
+    <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                What to do if you don't know the end-point assessment price
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p>
+                If you haven't selected an end-point assessment organisation (EPAO) or finalised the contract, you can enter a nominal value of £1 for the end-point assessment.
+                <br /><br />
+                Adjust the training price to reflect this. For example, if training costs £9,000, enter £8,999 for training and £1 for the end-point assessment.
+                <br /><br />
+                You can update both prices during the apprenticeship once the end-point assessment price is confirmed.
+                <br /><br />
+                Any increase in the total price will need employer approval.
+            </p>
+        </div>
+    </details>
+
     <div class="govuk-form-group @Html.AddClassIfPropertyInError(x => x.Cost, "govuk-form-group--error")">
         @Html.ValidationMessageFor(m => m.Cost, null, new { @class = "govuk-error-message", id = "error-message-" + Html.IdFor(m => m.Cost) })
 


### PR DESCRIPTION
**Add/Edit draft apprenticeship Help Text updates**

**Heading:** 
Apprentice training details → Apprenticeship training dates

**New heading:**
Apprenticeship price

**New text under heading 'Apprenticeship price':**
The total apprenticeship price covers training and end-point assessment costs, calculated automatically from your figures.

**New expanding sub-head and text:**
What to do if you don't know the end-point assessment price

If you haven't selected an end-point assessment organisation (EPAO) or finalised the contract, you can enter a nominal value of £1 for the end-point assessment.

Adjust the training price to reflect this. For example, if training costs £9,000, enter £8,999 for training and £1 for the end-point assessment.

You can update both prices during the apprenticeship once the end-point assessment price is confirmed.

Any increase in the total price will need employer approval.